### PR TITLE
Add workflow_run trigger event to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,10 @@
 # .github/worflows/publish.yaml
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: [Update daily data]
+    types:
+      - completed
   push:
     branches: main
 


### PR DESCRIPTION
Hi @shospital here's another attempt at getting the data update workflow to trigger the publish workflow. I found the `workflow_run` trigger event here: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run.